### PR TITLE
Added an example config for a local couchbase volume.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+dockerbits/couchdata
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dockerbits/couchdata
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,3 +34,6 @@ services:
     image: couchbase:community-6.5.0
     # ports:
     #   - 8091:8091
+    # Example for storing couchbase datasets locally.  This path must exist on your host.
+    # volumes:
+    #   - ./dockerbits/couchdata/dataset0:/opt/couchbase/var/lib/couchbase


### PR DESCRIPTION
If uncommented, this would allow couchbase data to persist when the couchbase
container is recreated.

Added the path to .gitignore and .dockerignore.